### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/wildimp/16e29885-cd66-4d37-823e-8d7221af9baf/c766275a-1b68-4207-8808-0bbb423f88c4/_apis/work/boardbadge/dc451375-d0bd-4462-ada6-462ef3d869dc)](https://dev.azure.com/wildimp/16e29885-cd66-4d37-823e-8d7221af9baf/_boards/board/t/c766275a-1b68-4207-8808-0bbb423f88c4/Microsoft.RequirementCategory)
 # win_software_needed
 装机必备


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.